### PR TITLE
chore(structure): add .gitignore for Python and Jupyter artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+
+# Jupyter
+.ipynb_checkpoints/
+*.ipynb_checkpoints
+
+# Environment
+.env
+venv/
+.venv/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# VS Code
+.vscode/settings.json


### PR DESCRIPTION
Adds .gitignore to exclude Python cache files, Jupyter checkpoint files, environment files, and OS artefacts from version control. Part of bringing repository up to engineering standard.